### PR TITLE
ci: run stubtests on Saturdays

### DIFF
--- a/.github/workflows/stubtest.yaml
+++ b/.github/workflows/stubtest.yaml
@@ -1,5 +1,9 @@
 name: Test Stubs
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 6'
 
 jobs:
   ci:


### PR DESCRIPTION
Change the scheduling rules for the stubtest GitHub workflow so that checks are executed every Saturday in addition to on pushes to `main` and pull requests.
This will allow us to have a weekly report of the healthiness of the stubs.